### PR TITLE
[Target] Added new targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ google-services.json
 
 # Android Profiling
 *.hprof
+.DS_Store

--- a/airdaydreamers/rpi5_car/Android.bp
+++ b/airdaydreamers/rpi5_car/Android.bp
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package {
+    default_applicable_licenses: ["device_airdaydreamers_car_license"],
+}
+
+// See: http://go/android-license-faq
+license {
+    name: "device_airdaydreamers_car_license",
+    visibility: [":__subpackages__"],
+    license_kinds: [
+        "SPDX-license-identifier-Apache-2.0",
+    ],
+    license_text: ["LICENSE"],
+}

--- a/airdaydreamers/rpi5_car/Android.mk
+++ b/airdaydreamers/rpi5_car/Android.mk
@@ -1,0 +1,6 @@
+# Declares files to be copied from the `device/generic/car` directory 
+# to the target device using the `declare-1p-copy-files` function. 
+# This function likely returns a list of file paths based on its internal logic 
+# (e.g., wildcards or specific file patterns).  The `eval` function then 
+# expands this list and triggers the actual file copy process.
+$(eval $(call declare-1p-copy-files,device/generic/car,))

--- a/airdaydreamers/rpi5_car/AndroidProducts.mk
+++ b/airdaydreamers/rpi5_car/AndroidProducts.mk
@@ -1,0 +1,9 @@
+PRODUCT_MAKEFILES := \
+    $(LOCAL_DIR)/rpi5_car.mk \
+    $(LOCAL_DIR)/rpi5_car_md.mk \
+    $(LOCAL_DIR)/rpi5_car_portrait.mk
+
+COMMON_LUNCH_CHOICES := \
+    rpi5_car-userdebug \
+    rpi5_car_md-userdebug \
+    rpi5_car_portrait-eng

--- a/airdaydreamers/rpi5_car/BoardConfig.mk
+++ b/airdaydreamers/rpi5_car/BoardConfig.mk
@@ -1,0 +1,79 @@
+#
+# Copyright 2020 Android-RPi Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+TARGET_NO_BOOTLOADER := true
+TARGET_NO_KERNEL := true
+TARGET_NO_RECOVERY := true
+
+TARGET_ARCH := arm64
+TARGET_ARCH_VARIANT := armv8-a
+TARGET_CPU_VARIANT := cortex-a76
+TARGET_CPU_ABI := arm64-v8a
+TARGET_CPU_ABI2 := 
+
+TARGET_DYNAMIC_64_32_MEDIASERVER := true
+
+TARGET_FLATTEN_APEX := true
+
+PRODUCT_FULL_TREBLE_OVERRIDE := true
+BOARD_VNDK_VERSION := current
+
+TARGET_BOARD_PLATFORM := bcm2711
+
+TARGET_USERIMAGES_SPARSE_EXT_DISABLED := true
+TARGET_USERIMAGES_USE_EXT4 := true
+
+# [VLAD_SMIRNOV]
+BOARD_SYSTEMIMAGE_PARTITION_SIZE := 2147483648 # 2GB 2048M
+BOARD_USERDATAIMAGE_PARTITION_SIZE := 134217728 # 128M
+
+TARGET_COPY_OUT_VENDOR := vendor
+BOARD_VENDORIMAGE_PARTITION_SIZE := 1073741824 # 1GB 1024M
+BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := ext4
+
+BOARD_FLASH_BLOCK_SIZE := 4096
+
+MALLOC_SVELTE := true
+
+USE_XML_AUDIO_POLICY_CONF := 1
+
+BOARD_MESA3D_USES_MESON_BUILD := true
+BOARD_MESA3D_GALLIUM_DRIVERS := v3d vc4
+BOARD_MESA3D_VULKAN_DRIVERS := broadcom
+USE_OPENGL_RENDERER := true
+TARGET_USES_HWC2 := true
+TARGET_SCREEN_DENSITY := 160
+
+# Wifi
+BOARD_WLAN_DEVICE := bcmdhd
+WPA_SUPPLICANT_VERSION := VER_0_8_X
+BOARD_WPA_SUPPLICANT_DRIVER := NL80211
+BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_bcmdhd
+BOARD_HOSTAPD_DRIVER := NL80211
+BOARD_HOSTAPD_PRIVATE_LIB   := lib_driver_cmd_bcmdhd
+WIFI_HIDL_UNIFIED_SUPPLICANT_SERVICE_RC_ENTRY := true
+
+# Bluetooth
+BOARD_HAVE_BLUETOOTH := true
+BOARD_HAVE_BLUETOOTH_BCM := true
+BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/arpi/rpi5/bluetooth
+BOARD_CUSTOM_BT_CONFIG := device/arpi/rpi5/bluetooth/vnd_rpi5.txt
+
+BOARD_SEPOLICY_DIRS := \
+    device/arpi/rpi5/sepolicy
+
+DEVICE_MANIFEST_FILE := device/arpi/rpi5/manifest.xml
+#DEVICE_MANIFEST_FILE := device/airdaydreamers/rpi5_car/manifest.xml

--- a/airdaydreamers/rpi5_car/LICENSE
+++ b/airdaydreamers/rpi5_car/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/airdaydreamers/rpi5_car/airdaydreamers_rp5_car_md.mk
+++ b/airdaydreamers/rpi5_car/airdaydreamers_rp5_car_md.mk
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2021-2024 Vladislav Smirnov
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#MD changes ====================================================================
+PRODUCT_PRODUCT_PROPERTIES+= \
+    ro.adb.secure=0
+
+# Overrides default display settings
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/display_layout_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/displayconfig/display_layout_configuration.xml \
+    $(LOCAL_PATH)/display_settings.xml:$(TARGET_COPY_OUT_VENDOR)/etc/display_settings.xml
+
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.managed_users.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.managed_users.xml
+
+PRODUCT_PACKAGE_OVERLAYS += \
+    device/generic/car/emulator/multi-display/overlay
+
+PRODUCT_PACKAGES += CarServiceOverlayMultiDisplay
+
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+    persist.sys.max_profiles=5 \
+    com.android.car.internal.debug.num_auto_populated_users=1
+
+PRODUCT_PACKAGES += \
+    MultiDisplaySecondaryHomeTestLauncher \
+    MultiDisplayTest
+
+# enables the rro package for passenger(secondary) user.
+ENABLE_PASSENGER_SYSTEMUI_RRO := true
+#MD changes ====================================================================

--- a/airdaydreamers/rpi5_car/display_layout_configuration.xml
+++ b/airdaydreamers/rpi5_car/display_layout_configuration.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<layouts>
+  <layout>
+    <!-- Use the default state -->
+    <state>-1</state>
+
+    <display enabled="true" defaultDisplay="true">
+      <address>4614449806218072320</address>
+    </display>
+
+    <display enabled="true" defaultDisplay="false" displayGroup="passenger_display1">
+      <address>4620250800518949377</address>
+    </display>
+
+    <display enabled="true" defaultDisplay="false" displayGroup="passenger_display2">
+      <address>4619195921270301697</address>
+    </display>
+
+    <display enabled="true" defaultDisplay="false" displayGroup="passenger_display3">
+      <address>4620250800518949378</address>
+    </display>
+  </layout>
+</layouts>

--- a/airdaydreamers/rpi5_car/display_settings.xml
+++ b/airdaydreamers/rpi5_car/display_settings.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<display-settings>
+    <!-- Use physical port number instead of local id -->
+    <config identifier="1" />
+
+    <display name="port:0"
+      shouldShowSystemDecors="true"
+      shouldShowIme="true"
+      forcedDensity="160" />
+
+    <display name="port:1"
+      shouldShowSystemDecors="true"
+      shouldShowIme="true"
+      forcedDensity="160" />
+
+  <!-- Display settings for cluster -->
+  <!--
+  <display name="port:1"
+      forcedDensity="120"
+      dontMoveToTop="true"/> -->
+
+  <!-- Display settings for 1st passenger display / 2nd Home -->
+    <display name="port:2"
+      shouldShowSystemDecors="true"
+      shouldShowIme="true"
+      forcedDensity="160" />
+
+  <!-- Display settings for 2nd passenger display / 3rd Home -->
+    <display name="port:3"
+      shouldShowSystemDecors="true"
+      shouldShowIme="true"
+      forcedDensity="160" />
+
+</display-settings>

--- a/airdaydreamers/rpi5_car/manifest.xml
+++ b/airdaydreamers/rpi5_car/manifest.xml
@@ -1,0 +1,125 @@
+<manifest version="1.0" type="device" target-level="2">
+    <hal format="hidl">
+        <name>android.hardware.audio</name>
+        <transport>hwbinder</transport>
+        <version>4.0</version>
+        <interface>
+            <name>IDevicesFactory</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@4.0::IDevicesFactory/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.audio.effect</name>
+        <transport>hwbinder</transport>
+        <version>4.0</version>
+        <interface>
+            <name>IEffectsFactory</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@4.0::IEffectsFactory/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.configstore</name>
+        <transport>hwbinder</transport>
+        <version>1.1</version>
+        <interface>
+            <name>ISurfaceFlingerConfigs</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.mapper</name>
+        <transport arch="64">passthrough</transport>
+        <version>4.0</version>
+        <interface>
+            <name>IMapper</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.memtrack</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IMemtrack</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.bluetooth</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IBluetoothHci</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.keymaster</name>
+        <transport>hwbinder</transport>
+        <version>3.0</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.camera.provider</name>
+        <transport>hwbinder</transport>
+        <version>2.5</version>
+        <interface>
+            <name>ICameraProvider</name>
+            <instance>external/0</instance>
+        </interface>
+    </hal> 
+
+
+
+
+
+
+     <hal format="hidl">
+        <name>android.hardware.automotive.vehicle</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IVehicle</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.broadcastradio</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IBroadcastRadio</name>
+            <instance>amfm</instance>
+            <instance>dab</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.automotive.can</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::ICanBus/test1</fqname>
+        <fqname>@1.0::ICanBus/test2</fqname>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.automotive.occupant_awareness</name>
+        <interface>
+            <name>IOccupantAwareness</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl" optional="true">
+       <name>android.automotive.computepipe.registry</name>
+       <interface>
+           <name>IPipeQuery</name>
+           <instance>router</instance>
+       </interface>
+       <interface>
+           <name>IPipeRegistration</name>
+           <instance>router</instance>
+       </interface>
+   </hal>   
+</manifest>

--- a/airdaydreamers/rpi5_car/overlays/multi_display/frameworks/base/core/res/res/values/config.xml
+++ b/airdaydreamers/rpi5_car/overlays/multi_display/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- this is important so guest knows we have two displays-->
+    <string-array name="config_displayUniqueIdArray" translatable="false">
+        <item>"local:4614449806218072320"</item>
+        <item>"local:4620250800518949377"</item>
+        <item>"local:4619195921270301697"</item>
+        <item>"local:4620250800518949378"</item>
+    </string-array>
+
+
+    <!-- Whether the system enables per-display focus. If the system has the input method for each
+         display, this value should be true. -->
+    <bool name="config_perDisplayFocusEnabled">true</bool>
+
+    <!--  Maximum number of supported users -->
+    <integer name="config_multiuserMaximumUsers">10</integer>
+
+    <!-- Maximum number of users we allow to be running at a time -->
+    <integer name="config_multiuserMaxRunningUsers">5</integer>
+
+    <!-- True if the device supports system decorations on secondary displays. -->
+    <bool name="config_supportsSystemDecorsOnSecondaryDisplays">true</bool>
+    <!-- This is the default launcher package with an activity to use on secondary displays that
+         support system decorations.
+         This launcher package must have an activity that supports multiple instances and has
+         corresponding launch mode set in AndroidManifest.
+         {@see android.view.Display#FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS} -->
+
+    <string name="config_secondaryHomePackage" translatable="false">com.android.car.multidisplay</string>
+
+
+    <!-- Whether to only install system packages on a user if they're whitelisted for that user
+         type. These are flags and can be freely combined.
+         0  - disable whitelist (install all system packages; no logging)
+         1  - enforce (only install system packages if they are whitelisted)
+         2  - log (log non-whitelisted packages)
+         4  - any package not mentioned in the whitelist file is implicitly whitelisted on all users
+         8  - same as 4, but just for the SYSTEM user
+         16 - ignore OTAs (don't install system packages during OTAs)
+         Common scenarios:
+          - to enable feature (fully enforced) for a complete whitelist: 1
+          - to enable feature for an incomplete whitelist (so use implicit whitelist mode): 5
+          - to enable feature but implicitly whitelist for SYSTEM user to ease local development: 9
+          - to disable feature completely if it had never been enabled: 16
+          - to henceforth disable feature and try to undo its previous effects: 0
+        Note: This list must be kept current with PACKAGE_WHITELIST_MODE_PROP in
+        frameworks/base/services/core/java/com/android/server/pm/UserSystemPackageInstaller.java
+        Package whitelist disabled for testing profile user as default whitelist does not
+        support PROFILE user. -->
+    <integer name="config_userTypePackageWhitelistMode">2</integer>
+
+    <!-- Whether the device allows users to start in background visible on displays.
+         Should be false for most devices, except automotive vehicle with passenger displays. -->
+    <!-- The config is enabled for the development purpose only. -->
+    <bool name="config_multiuserVisibleBackgroundUsers">true</bool>
+
+    <!-- Enable multi-user IME sessions -->
+    <string translatable="false" name="config_deviceSpecificInputMethodManagerService">com.android.server.inputmethod.InputMethodManagerServiceProxy$Lifecycle</string>
+
+    <!-- Whether the device allows users to start in background visible on the default display.
+         Should be false for most devices, except passenger-only automotive build (i.e., when
+         Android runs in a separate system in the back seat to manage the passenger displays) -->
+    <!-- The config is enabled for the development purpose only. -->
+    <bool name="config_multiuserVisibleBackgroundUsersOnDefaultDisplay">true</bool>
+</resources>

--- a/airdaydreamers/rpi5_car/overlays/multi_display/frameworks/base/core/res/res/xml/config_user_types.xml
+++ b/airdaydreamers/rpi5_car/overlays/multi_display/frameworks/base/core/res/res/xml/config_user_types.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<user-types>
+    <full-type name="android.os.usertype.full.SECONDARY" >
+        <default-restrictions />
+    </full-type>
+
+    <full-type name="android.os.usertype.full.GUEST" >
+        <default-restrictions no_factory_reset="true" no_remove_user="true"
+                  no_modify_accounts="true" no_install_apps="true" no_install_unknown_sources="true"
+                  no_uninstall_apps="true"/>
+    </full-type>
+
+    <profile-type name="android.os.usertype.profile.CLONE"
+        enabled='0' >
+    </profile-type>
+</user-types>

--- a/airdaydreamers/rpi5_car/rpi5_car.mk
+++ b/airdaydreamers/rpi5_car/rpi5_car.mk
@@ -1,0 +1,203 @@
+#
+# Copyright 2024 Vladislav Smirnov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DEVICE_IS_64BIT_ONLY := true
+
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
+$(call inherit-product, packages/services/Car/car_product/build/car.mk)
+
+PRODUCT_NAME := rpi5_car
+PRODUCT_DEVICE := rpi5_car
+PRODUCT_BRAND := Airdaydreamers
+PRODUCT_MANUFACTURER := Airdaydreamers and ARPi
+PRODUCT_MODEL := Raspberry Pi 5
+
+include frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    debug.drm.mode.force=1920x1080 \
+    gralloc.drm.kms=/dev/dri/card1 \
+    ro.opengles.version=196609 \
+    ro.hardware.vulkan=broadcom \
+    ro.hardware.egl=mesa \
+    ro.hdmi.device_type=4 \
+    wifi.interface=wlan0 \
+    ro.rfkilldisabled=1
+
+# overlay packages
+PRODUCT_PACKAGES += \
+    RpFrameworkOverlay
+
+# system packages
+PRODUCT_PACKAGES += \
+    gralloc.rpi5 \
+    vulkan.broadcom \
+    memtrack.rpi5 \
+    audio.primary.rpi5 \
+    audio.usb.default \
+    audio.r_submix.default \
+    wificond \
+    wifilogd \
+    wpa_supplicant \
+    wpa_supplicant.conf \
+    hostapd \
+    libbt-vendor
+
+# graphics hal
+PRODUCT_PACKAGES += \
+    libEGL_mesa \
+    libGLESv1_CM_mesa \
+    libGLESv2_mesa \
+    libgallium_dri \
+    libglapi
+
+# hardware/interfaces
+PRODUCT_PACKAGES += \
+    android.hardware.graphics.allocator-service.arpi \
+    android.hardware.graphics.mapper@4.0-impl.arpi \
+    android.hardware.graphics.composer-service.arpi \
+    android.hardware.camera.provider@2.5-external-service \
+    android.hardware.audio@4.0-impl \
+    android.hardware.audio.effect@4.0-impl \
+    android.hardware.audio.service \
+    android.hardware.keymaster@3.0-impl \
+    android.hardware.keymaster@3.0-service \
+    android.hardware.gatekeeper@1.0-service.software \
+    android.hardware.memtrack@1.0-impl \
+    android.hardware.memtrack@1.0-service \
+    android.hardware.health@2.1-service \
+    android.hardware.health@2.1-impl \
+    android.hardware.health.storage@1.0-service \
+    android.hardware.wifi@1.0-service \
+    android.hardware.bluetooth@1.0-service \
+    android.hardware.bluetooth@1.0-impl \
+    android.hardware.configstore@1.1-service \
+    android.hardware.tv.hdmi.connection-service \
+    android.hardware.tv.hdmi.cec-service \
+    android.hardware.tv.hdmi.earc-service \
+    hwservicemanager \
+    vndservicemanager
+
+# REGION NEW CHANGES
+# [VLAD_SMIRNOV]Auto modules
+PRODUCT_PACKAGES += \
+            android.hardware.broadcastradio@2.0-service \
+            android.hardware.automotive.vehicle@2.0-default-service \
+            CarServiceUpdatableNonModule
+
+# Car init.rc
+PRODUCT_COPY_FILES += \
+            packages/services/Car/car_product/init/init.bootstat.rc:root/init.bootstat.rc \
+            packages/services/Car/car_product/init/init.car.rc:root/init.car.rc
+
+# Enable landscape
+PRODUCT_COPY_FILES += \
+            frameworks/native/data/etc/android.hardware.screen.landscape.xml:system/etc/permissions/android.hardware.screen.landscape.xml
+
+# Used to embed a map in an activity view
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.activities_on_secondary_displays.xml
+
+# broadcast radio feature
+PRODUCT_COPY_FILES += \
+        frameworks/native/data/etc/android.hardware.broadcastradio.xml:system/etc/permissions/android.hardware.broadcastradio.xml
+
+TARGET_USES_CAR_FUTURE_FEATURES := true
+
+# Include EVS reference implementations
+ENABLE_EVS_SAMPLE := true
+# ENDREGION
+
+# system configurations
+PRODUCT_COPY_FILES := \
+    hardware/broadcom/wlan/bcmdhd/config/wpa_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/wpa_supplicant_overlay.conf \
+    frameworks/native/data/etc/android.hardware.vulkan.level-1.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.vulkan.level.xml \
+    frameworks/native/data/etc/android.hardware.vulkan.version-1_1.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.vulkan.version.xml \
+    frameworks/native/data/etc/android.hardware.ethernet.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.ethernet.xml \
+    frameworks/native/data/etc/android.hardware.usb.host.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.usb.host.xml \
+    frameworks/native/data/etc/android.hardware.hdmi.cec.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.hdmi.cec.xml \
+    frameworks/native/data/etc/android.hardware.wifi.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.wifi.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth_le.xml \
+    frameworks/native/data/etc/android.hardware.camera.external.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.external.xml \
+    device/arpi/rpi5/etc/external_camera_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/external_camera_config.xml \
+    device/arpi/rpi5/init.usb.rc:root/init.usb.rc \
+    device/arpi/rpi5/init.rpi5.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.rpi5.rc \
+    device/arpi/rpi5/init.rpi5.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.rpi5.usb.rc \
+    device/arpi/rpi5/ueventd.rc:$(TARGET_COPY_OUT_VENDOR)/etc/ueventd.rc \
+    device/arpi/rpi5/fstab.rpi5:$(TARGET_COPY_OUT_VENDOR)/etc/fstab.rpi5 \
+    device/arpi/rpi5/fstab.rpi5:$(TARGET_COPY_OUT_RAMDISK)/fstab.rpi5 \
+    device/arpi/rpi5/Generic.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/Generic.kl \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.bin:root/lib/firmware/brcm/brcmfmac43455-sdio.bin \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.bin:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.bin \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.clm_blob:root/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.clm_blob:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.txt:root/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.txt:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt \
+    device/arpi/rpi5/firmware/brcm/BCM4345C0.hcd:root/lib/firmware/brcm/BCM4345C0.hcd \
+    device/arpi/rpi5/bluetooth/bt_vendor.conf:system/etc/bluetooth/bt_vendor.conf \
+    $(PRODUCT_COPY_FILES)
+
+# media configurations
+PRODUCT_COPY_FILES := \
+    device/generic/goldfish/camera/media/profiles.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles.xml \
+    device/generic/goldfish/camera/media/codecs.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
+    frameworks/av/media/libeffects/data/audio_effects.conf:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.conf \
+    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_telephony.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_video.xml \
+    frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
+    frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
+    device/arpi/rpi5/etc/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \
+    frameworks/base/data/sounds/effects/ogg/Effect_Tick_48k.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ui/Effect_Tick.ogg \
+    frameworks/base/data/sounds/effects/ogg/camera_click_48k.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ui/camera_click.ogg \
+    $(PRODUCT_COPY_FILES)
+
+# REGION NEW CHANGES
+# [VLAD_SMIRNOV]
+# Additional permissions
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth_le.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth.xml \
+    frameworks/native/data/etc/android.hardware.broadcastradio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.broadcastradio.xml \
+    frameworks/native/data/etc/android.hardware.type.automotive.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.type.automotive.xml
+
+#PRODUCT_AAPT_PREF_CONFIG := tvdpi
+PRODUCT_CHARACTERISTICS := automotive
+
+# These are things from atv_base, which android-rpi is based on, 
+# that aren't in automotive builds.
+
+$(call inherit-product-if-exists, frameworks/base/data/fonts/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/dancing-script/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/carrois-gothic-sc/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/coming-soon/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/cutive-mono/fonts.mk)
+$(call inherit-product-if-exists, external/noto-fonts/fonts.mk)
+$(call inherit-product-if-exists, external/roboto-fonts/fonts.mk)
+$(call inherit-product-if-exists, external/hyphenation-patterns/patterns.mk)
+$(call inherit-product-if-exists, frameworks/base/data/keyboards/keyboards.mk)
+$(call inherit-product-if-exists, frameworks/webview/chromium/chromium.mk)
+
+PRODUCT_PACKAGES += \
+    librs_jni \
+    cameraserver
+
+# ENDREGION
+$(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)

--- a/airdaydreamers/rpi5_car/rpi5_car_md.mk
+++ b/airdaydreamers/rpi5_car/rpi5_car_md.mk
@@ -1,0 +1,258 @@
+#
+# Copyright 2024 Vladislav Smirnov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DEVICE_IS_64BIT_ONLY := true
+
+$(call inherit-product, $(LOCAL_PATH)/airdaydreamers_rp5_car_md.mk)
+
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
+$(call inherit-product, packages/services/Car/car_product/build/car.mk)
+
+
+# TODO(b/266978709): Set it to true after cleaning up the system partition
+# changes from this makefile
+PRODUCT_ENFORCE_ARTIFACT_PATH_REQUIREMENTS := false
+
+include frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+
+
+#PRODUCT_PACKAGES += \
+#    ClusterHomeSample \
+#    ClusterOsDouble \
+#    CarServiceOverlayEmulatorOsDouble \
+#    CarServiceOverlayMdEmulatorOsDouble \
+#    MultiDisplaySecondaryHomeTestLauncher \
+#    SecondaryHomeApp \
+#    MultiDisplayProvider \
+#    CarServiceMultiDisplayOverlayEmulator \
+#    MultiDisplayTest
+
+
+#ENABLE_CLUSTER_OS_DOUBLE:=true
+#PRODUCT_PACKAGES += ClusterHomeSample ClusterOsDouble ClusterHomeSampleOverlay ClusterOsDoubleEmulatorVirtualDisplayOverlay
+
+#PRODUCT_COPY_FILES += \
+#    device/generic/car/emulator/multi-display/car_audio_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/car_audio_configuration.xml
+#    device/google/trout/product_files/vendor/etc/car_audio_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/car_audio_configuration.xml \
+#    device/google/cuttlefish/shared/auto/car_audio_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/car_audio_configuration.xml \
+#    device/google/cuttlefish/shared/auto/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml
+
+#PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+#    ro.vendor.simulateMultiZoneAudio=true
+
+#PRODUCT_PACKAGES += \
+#   android.hardware.graphics.composer@2.4-service
+#    android.hardware.graphics.composer-service.arpi
+    
+
+# Graphics
+#PRODUCT_PACKAGES += \
+#    android.hardware.graphics.allocator@4.0-service.minigbm_gbm_mesa \
+#    android.hardware.graphics.mapper@4.0-impl.minigbm_gbm_mesa \
+#    libgbm_mesa_wrapper
+
+#PRODUCT_PACKAGES += \
+#    android.hardware.graphics.allocator-service.arpi \
+#    android.hardware.graphics.mapper@4.0-impl.arpi
+
+#MD changes ====================================================================
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    debug.drm.mode.force=1920x1080 \
+    gralloc.drm.kms=/dev/dri/card1 \
+    ro.opengles.version=196609 \
+    ro.hardware.vulkan=broadcom \
+    ro.hardware.egl=mesa \
+    ro.hdmi.device_type=4 \
+    wifi.interface=wlan0 \
+    ro.rfkilldisabled=1
+
+# overlay packages
+PRODUCT_PACKAGES += \
+    RpFrameworkOverlay
+
+# system packages
+PRODUCT_PACKAGES += \
+    gralloc.rpi5 \
+    vulkan.broadcom \
+    memtrack.rpi5 \
+    audio.primary.rpi5 \
+    audio.usb.default \
+    audio.r_submix.default \
+    wificond \
+    wifilogd \
+    wpa_supplicant \
+    wpa_supplicant.conf \
+    hostapd \
+    libbt-vendor
+
+# graphics hal
+PRODUCT_PACKAGES += \
+    libEGL_mesa \
+    libGLESv1_CM_mesa \
+    libGLESv2_mesa \
+    libgallium_dri \
+    libglapi
+
+# hardware/interfaces
+PRODUCT_PACKAGES += \
+    android.hardware.graphics.allocator-service.arpi \
+    android.hardware.graphics.mapper@4.0-impl.arpi \
+    android.hardware.graphics.composer-service.arpi \
+    android.hardware.camera.provider@2.5-external-service \
+    android.hardware.audio@4.0-impl \
+    android.hardware.audio.effect@4.0-impl \
+    android.hardware.audio.service \
+    android.hardware.keymaster@3.0-impl \
+    android.hardware.keymaster@3.0-service \
+    android.hardware.gatekeeper@1.0-service.software \
+    android.hardware.memtrack@1.0-impl \
+    android.hardware.memtrack@1.0-service \
+    android.hardware.health@2.1-service \
+    android.hardware.health@2.1-impl \
+    android.hardware.health.storage@1.0-service \
+    android.hardware.wifi@1.0-service \
+    android.hardware.bluetooth@1.0-service \
+    android.hardware.bluetooth@1.0-impl \
+    android.hardware.configstore@1.1-service \
+    android.hardware.tv.hdmi.connection-service \
+    android.hardware.tv.hdmi.cec-service \
+    android.hardware.tv.hdmi.earc-service \
+    hwservicemanager \
+    vndservicemanager
+
+# REGION NEW CHANGES
+# [VLAD_SMIRNOV]Auto modules
+PRODUCT_PACKAGES += \
+            android.hardware.broadcastradio@2.0-service \
+            android.hardware.automotive.vehicle@2.0-default-service \
+            CarServiceUpdatableNonModule
+
+# Car init.rc
+PRODUCT_COPY_FILES += \
+            packages/services/Car/car_product/init/init.bootstat.rc:root/init.bootstat.rc \
+            packages/services/Car/car_product/init/init.car.rc:root/init.car.rc
+
+# Enable landscape
+PRODUCT_COPY_FILES += \
+            frameworks/native/data/etc/android.hardware.screen.landscape.xml:system/etc/permissions/android.hardware.screen.landscape.xml
+
+# Used to embed a map in an activity view
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.activities_on_secondary_displays.xml
+
+## Enable activities on secondary displays
+#PRODUCT_COPY_FILES += \
+#        frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:system/etc/permissions/android.software.activities_on_secondary_displays.xml
+
+# broadcast radio feature
+PRODUCT_COPY_FILES += \
+        frameworks/native/data/etc/android.hardware.broadcastradio.xml:system/etc/permissions/android.hardware.broadcastradio.xml
+
+TARGET_USES_CAR_FUTURE_FEATURES := true
+
+# Include EVS reference implementations
+ENABLE_EVS_SAMPLE := true
+# ENDREGION
+
+# system configurations
+PRODUCT_COPY_FILES := \
+    hardware/broadcom/wlan/bcmdhd/config/wpa_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/wpa_supplicant_overlay.conf \
+    frameworks/native/data/etc/android.hardware.vulkan.level-1.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.vulkan.level.xml \
+    frameworks/native/data/etc/android.hardware.vulkan.version-1_1.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.vulkan.version.xml \
+    frameworks/native/data/etc/android.hardware.ethernet.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.ethernet.xml \
+    frameworks/native/data/etc/android.hardware.usb.host.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.usb.host.xml \
+    frameworks/native/data/etc/android.hardware.hdmi.cec.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.hdmi.cec.xml \
+    frameworks/native/data/etc/android.hardware.wifi.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.wifi.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth_le.xml \
+    frameworks/native/data/etc/android.hardware.camera.external.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.external.xml \
+    device/arpi/rpi5/etc/external_camera_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/external_camera_config.xml \
+    device/arpi/rpi5/init.usb.rc:root/init.usb.rc \
+    device/arpi/rpi5/init.rpi5.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.rpi5.rc \
+    device/arpi/rpi5/init.rpi5.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.rpi5.usb.rc \
+    device/arpi/rpi5/ueventd.rc:$(TARGET_COPY_OUT_VENDOR)/etc/ueventd.rc \
+    device/arpi/rpi5/fstab.rpi5:$(TARGET_COPY_OUT_VENDOR)/etc/fstab.rpi5 \
+    device/arpi/rpi5/fstab.rpi5:$(TARGET_COPY_OUT_RAMDISK)/fstab.rpi5 \
+    device/arpi/rpi5/Generic.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/Generic.kl \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.bin:root/lib/firmware/brcm/brcmfmac43455-sdio.bin \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.bin:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.bin \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.clm_blob:root/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.clm_blob:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.txt:root/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.txt:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt \
+    device/arpi/rpi5/firmware/brcm/BCM4345C0.hcd:root/lib/firmware/brcm/BCM4345C0.hcd \
+    device/arpi/rpi5/bluetooth/bt_vendor.conf:system/etc/bluetooth/bt_vendor.conf \
+    $(PRODUCT_COPY_FILES)
+
+# media configurations
+PRODUCT_COPY_FILES := \
+    device/generic/goldfish/camera/media/profiles.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles.xml \
+    device/generic/goldfish/camera/media/codecs.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
+    frameworks/av/media/libeffects/data/audio_effects.conf:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.conf \
+    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_telephony.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_video.xml \
+    frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
+    frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
+    frameworks/base/data/sounds/effects/ogg/Effect_Tick_48k.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ui/Effect_Tick.ogg \
+    frameworks/base/data/sounds/effects/ogg/camera_click_48k.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ui/camera_click.ogg \
+    $(PRODUCT_COPY_FILES)
+
+# REGION NEW CHANGES
+# [VLAD_SMIRNOV]
+# Additional permissions
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth_le.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth.xml \
+    frameworks/native/data/etc/android.hardware.broadcastradio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.broadcastradio.xml \
+    frameworks/native/data/etc/android.hardware.type.automotive.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.type.automotive.xml
+
+#PRODUCT_AAPT_PREF_CONFIG := tvdpi
+PRODUCT_CHARACTERISTICS := automotive
+
+# These are things from atv_base, which android-rpi is based on, 
+# that aren't in automotive builds.
+
+$(call inherit-product-if-exists, frameworks/base/data/fonts/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/dancing-script/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/carrois-gothic-sc/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/coming-soon/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/cutive-mono/fonts.mk)
+$(call inherit-product-if-exists, external/noto-fonts/fonts.mk)
+$(call inherit-product-if-exists, external/roboto-fonts/fonts.mk)
+$(call inherit-product-if-exists, external/hyphenation-patterns/patterns.mk)
+$(call inherit-product-if-exists, frameworks/base/data/keyboards/keyboards.mk)
+$(call inherit-product-if-exists, frameworks/webview/chromium/chromium.mk)
+
+# Window extensions
+$(call inherit-product, $(SRC_TARGET_DIR)/product/window_extensions.mk)
+
+PRODUCT_PACKAGES += \
+    librs_jni \
+    cameraserver
+
+# ENDREGION
+$(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
+
+PRODUCT_NAME := rpi5_car_md
+PRODUCT_DEVICE := rpi5_car
+PRODUCT_BRAND := Airdaydreamers
+PRODUCT_MANUFACTURER := Airdaydreamers and ARPi
+PRODUCT_MODEL := Raspberry Pi 5

--- a/airdaydreamers/rpi5_car/rpi5_car_portrait.mk
+++ b/airdaydreamers/rpi5_car/rpi5_car_portrait.mk
@@ -1,0 +1,224 @@
+#
+# Copyright 2024 Vladislav Smirnov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DEVICE_IS_64BIT_ONLY := true
+
+# [VLAD_SMIRNOV]
+# Exclude AAE Car System UI
+DO_NOT_INCLUDE_AAE_CAR_SYSTEM_UI := true
+# [VLAD_SMIRNOV]
+# Exclude Car UI Reference Design
+DO_NOT_INCLUDE_CAR_UI_REFERENCE_DESIGN := true
+# [VLAD_SMIRNOV]
+# Exclude Car Visual Overlay
+DISABLE_CAR_PRODUCT_VISUAL_OVERLAY := true
+
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
+$(call inherit-product, packages/services/Car/car_product/build/car.mk)
+
+# [VLAD_SMIRNOV]
+# Copy additional files
+PRODUCT_COPY_FILES += \
+    packages/services/Car/car_product/car_ui_portrait/bootanimation/bootanimation.zip:system/media/bootanimation.zip
+
+PRODUCT_NAME := rpi5_car_portrait
+PRODUCT_DEVICE := rpi5_car
+PRODUCT_BRAND := Airdaydreamers
+PRODUCT_MANUFACTURER := Airdaydreamers and ARPi
+PRODUCT_MODEL := Raspberry Pi 5
+
+$(call inherit-product, packages/services/Car/car_product/car_ui_portrait/apps/car_ui_portrait_apps.mk)
+$(call inherit-product, packages/services/Car/car_product/car_ui_portrait/rro/car_ui_portrait_rro.mk)
+
+include frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+
+# [VLAD_SMIRNOV]
+PRODUCT_COPY_FILES += \
+    packages/services/Car/car_product/car_ui_portrait/car_ui_portrait_hardware.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/car_ui_portrait_hardware.xml
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    debug.drm.mode.force=1080x1920 \
+    gralloc.drm.kms=/dev/dri/card1 \
+    ro.opengles.version=196609 \
+    ro.hardware.vulkan=broadcom \
+    ro.hardware.egl=mesa \
+    ro.hdmi.device_type=4 \
+    wifi.interface=wlan0 \
+    ro.rfkilldisabled=1
+
+# overlay packages
+PRODUCT_PACKAGES += \
+    RpFrameworkOverlay
+
+# system packages
+PRODUCT_PACKAGES += \
+    gralloc.rpi5 \
+    vulkan.broadcom \
+    memtrack.rpi5 \
+    audio.primary.rpi5 \
+    audio.usb.default \
+    audio.r_submix.default \
+    wificond \
+    wifilogd \
+    wpa_supplicant \
+    wpa_supplicant.conf \
+    hostapd \
+    libbt-vendor
+
+# graphics hal
+PRODUCT_PACKAGES += \
+    libEGL_mesa \
+    libGLESv1_CM_mesa \
+    libGLESv2_mesa \
+    libgallium_dri \
+    libglapi
+
+# hardware/interfaces
+PRODUCT_PACKAGES += \
+    android.hardware.graphics.allocator-service.arpi \
+    android.hardware.graphics.mapper@4.0-impl.arpi \
+    android.hardware.graphics.composer-service.arpi \
+    android.hardware.camera.provider@2.5-external-service \
+    android.hardware.audio@4.0-impl \
+    android.hardware.audio.effect@4.0-impl \
+    android.hardware.audio.service \
+    android.hardware.keymaster@3.0-impl \
+    android.hardware.keymaster@3.0-service \
+    android.hardware.gatekeeper@1.0-service.software \
+    android.hardware.memtrack@1.0-impl \
+    android.hardware.memtrack@1.0-service \
+    android.hardware.health@2.1-service \
+    android.hardware.health@2.1-impl \
+    android.hardware.health.storage@1.0-service \
+    android.hardware.wifi@1.0-service \
+    android.hardware.bluetooth@1.0-service \
+    android.hardware.bluetooth@1.0-impl \
+    android.hardware.configstore@1.1-service \
+    android.hardware.tv.hdmi.connection-service \
+    android.hardware.tv.hdmi.cec-service \
+    android.hardware.tv.hdmi.earc-service \
+    hwservicemanager \
+    vndservicemanager
+
+# REGION NEW CHANGES
+# [VLAD_SMIRNOV]Auto modules
+PRODUCT_PACKAGES += \
+            android.hardware.broadcastradio@2.0-service \
+            android.hardware.automotive.vehicle@2.0-default-service \
+            CarServiceUpdatableNonModule
+
+# Car init.rc
+PRODUCT_COPY_FILES += \
+            packages/services/Car/car_product/init/init.bootstat.rc:root/init.bootstat.rc \
+            packages/services/Car/car_product/init/init.car.rc:root/init.car.rc
+
+# Enable portrait
+PRODUCT_COPY_FILES += \
+            frameworks/native/data/etc/android.hardware.screen.portrait.xml:system/etc/permissions/aandroid.hardware.screen.portrait.xml
+
+# Used to embed a map in an activity view
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.activities_on_secondary_displays.xml
+
+# broadcast radio feature
+PRODUCT_COPY_FILES += \
+        frameworks/native/data/etc/android.hardware.broadcastradio.xml:system/etc/permissions/android.hardware.broadcastradio.xml
+
+TARGET_USES_CAR_FUTURE_FEATURES := true
+
+# Include EVS reference implementations
+ENABLE_EVS_SAMPLE := true
+# ENDREGION
+
+# system configurations
+PRODUCT_COPY_FILES := \
+    hardware/broadcom/wlan/bcmdhd/config/wpa_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/wpa_supplicant_overlay.conf \
+    frameworks/native/data/etc/android.hardware.vulkan.level-1.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.vulkan.level.xml \
+    frameworks/native/data/etc/android.hardware.vulkan.version-1_1.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.vulkan.version.xml \
+    frameworks/native/data/etc/android.hardware.ethernet.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.ethernet.xml \
+    frameworks/native/data/etc/android.hardware.usb.host.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.usb.host.xml \
+    frameworks/native/data/etc/android.hardware.hdmi.cec.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.hdmi.cec.xml \
+    frameworks/native/data/etc/android.hardware.wifi.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.wifi.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth_le.xml \
+    frameworks/native/data/etc/android.hardware.camera.external.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.external.xml \
+    device/arpi/rpi5/etc/external_camera_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/external_camera_config.xml \
+    device/arpi/rpi5/init.usb.rc:root/init.usb.rc \
+    device/arpi/rpi5/init.rpi5.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.rpi5.rc \
+    device/arpi/rpi5/init.rpi5.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.rpi5.usb.rc \
+    device/arpi/rpi5/ueventd.rc:$(TARGET_COPY_OUT_VENDOR)/etc/ueventd.rc \
+    device/arpi/rpi5/fstab.rpi5:$(TARGET_COPY_OUT_VENDOR)/etc/fstab.rpi5 \
+    device/arpi/rpi5/fstab.rpi5:$(TARGET_COPY_OUT_RAMDISK)/fstab.rpi5 \
+    device/arpi/rpi5/Generic.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/Generic.kl \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.bin:root/lib/firmware/brcm/brcmfmac43455-sdio.bin \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.bin:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.bin \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.clm_blob:root/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.clm_blob:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.txt:root/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt \
+    device/arpi/rpi5/firmware/brcm/brcmfmac43455-sdio.txt:$(TARGET_COPY_OUT_RAMDISK)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt \
+    device/arpi/rpi5/firmware/brcm/BCM4345C0.hcd:root/lib/firmware/brcm/BCM4345C0.hcd \
+    device/arpi/rpi5/bluetooth/bt_vendor.conf:system/etc/bluetooth/bt_vendor.conf \
+    $(PRODUCT_COPY_FILES)
+
+# media configurations
+PRODUCT_COPY_FILES := \
+    device/generic/goldfish/camera/media/profiles.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles.xml \
+    device/generic/goldfish/camera/media/codecs.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
+    frameworks/av/media/libeffects/data/audio_effects.conf:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.conf \
+    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_telephony.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_video.xml \
+    frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
+    frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
+    device/arpi/rpi5/etc/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \
+    frameworks/base/data/sounds/effects/ogg/Effect_Tick_48k.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ui/Effect_Tick.ogg \
+    frameworks/base/data/sounds/effects/ogg/camera_click_48k.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ui/camera_click.ogg \
+    $(PRODUCT_COPY_FILES)
+
+# REGION CHANGES
+# [VLAD_SMIRNOV]
+# Additional permissions
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth_le.xml \
+    frameworks/native/data/etc/android.hardware.bluetooth.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.bluetooth.xml \
+    frameworks/native/data/etc/android.hardware.broadcastradio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.broadcastradio.xml \
+    frameworks/native/data/etc/android.hardware.type.automotive.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.type.automotive.xml
+
+PRODUCT_CHARACTERISTICS := automotive
+
+# These are things from atv_base, which android-rpi is based on, 
+# that aren't in automotive builds.
+
+$(call inherit-product-if-exists, frameworks/base/data/fonts/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/dancing-script/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/carrois-gothic-sc/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/coming-soon/fonts.mk)
+$(call inherit-product-if-exists, external/google-fonts/cutive-mono/fonts.mk)
+$(call inherit-product-if-exists, external/noto-fonts/fonts.mk)
+$(call inherit-product-if-exists, external/roboto-fonts/fonts.mk)
+$(call inherit-product-if-exists, external/hyphenation-patterns/patterns.mk)
+$(call inherit-product-if-exists, frameworks/base/data/keyboards/keyboards.mk)
+$(call inherit-product-if-exists, frameworks/webview/chromium/chromium.mk)
+
+PRODUCT_PACKAGES += \
+    librs_jni \
+    cameraserver
+
+# ENDREGION
+$(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)

--- a/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/Android.bp
+++ b/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/Android.bp
@@ -1,0 +1,35 @@
+// Copyright (C) 2024 Vladislav Smirnov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+package {
+    default_applicable_licenses: ["device_airdaydreamers_car_license"],
+}
+
+runtime_resource_overlay {
+    name: "CarServiceOverlayMultiDisplay",
+    resource_dirs: ["res"],
+    manifest: "AndroidManifest.xml",
+    sdk_version: "current",
+    product_specific: true
+}
+
+override_runtime_resource_overlay {
+    name: "CarServiceOverlayMultiDisplayGoogle",
+    base: "CarServiceOverlayMultiDisplay",
+    package_name: "com.google.android.car.resources.multi_display",
+    target_package_name: "com.google.android.car.updatable",
+}
+

--- a/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/AndroidManifest.xml
+++ b/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2024 Vladislav Smirnov
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.android.car.resources.multi_display">
+    <application android:hasCode="false"/>
+    <!-- priority should be higher than CarServiceOverlayMdEmulatorOsDouble -->
+    <overlay android:priority="5010"
+             android:targetPackage="com.android.car.updatable"
+             android:targetName="CarServiceCustomization"
+             android:resourcesMap="@xml/overlays"
+             android:isStatic="true" />
+</manifest>
+

--- a/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/res/values/config.xml
+++ b/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/res/values/config.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2024, Vladislav Smirnov
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- Resources to configure car service based on each OEM's preference. -->
+<resources>
+    <!--
+    Lists all occupant zones available in the car.
+    Some examples are:
+    <item>occupantZoneId=0,occupantType=DRIVER,seatRow=1,seatSide=driver</item>
+    <item>occupantZoneId=1,occupantType=FRONT_PASSENGER,seatRow=1,seatSide=oppositeDriver</item>
+    <item>occupantZoneId=2,occupantType=REAR_PASSENGER,seatRow=2,seatSide=left</item>
+    <item>occupantZoneId=3,occupantType=REAR_PASSENGER,seatRow=2,seatSide=right</item>
+
+    occupantZoneId: Unique unsigned integer id to represent each passenger zone. Each zone
+                    should have different id.
+    occupantType: Occupant type for the display. Use * part from
+                   CarOccupantZoneManager.OCCUPANT_TYPE_* like DRIVER, FRONT_PASSENGER,
+                   REAR_PASSENGER and etc.
+    seatRow: Integer telling which row the seat is located. Row 1 is for front seats.
+    seatSide: left/center/right for known side. Or can use driver/center/oppositeDriver to
+              handle both right-hand driving and left-hand driving in one place.
+              If car's RHD / LHD is not specified, LHD will be assumed and driver side becomes
+              left.
+    -->
+    <string-array translatable="false" name="config_occupant_zones">
+        <item>occupantZoneId=0,occupantType=DRIVER,seatRow=1,seatSide=driver</item>
+        <item>occupantZoneId=1,occupantType=FRONT_PASSENGER,seatRow=1,seatSide=oppositeDriver</item>
+        <item>occupantZoneId=2,occupantType=REAR_PASSENGER,seatRow=2,seatSide=left</item>
+        <item>occupantZoneId=3,occupantType=REAR_PASSENGER,seatRow=2,seatSide=right</item>
+    </string-array>
+
+    <!--
+        Specifies configuration of displays in system telling its usage / type and assigned
+        occupant.
+
+        Some examples are:
+        <item>displayPort=0,displayType=MAIN,occupantZoneId=0,inputTypes=TOUCH_SCREEN|DPAD_KEYS|NAVIGATE_KEYS|ROTARY_NAVIGATION</item>
+        <item>displayPort=1,displayType=INSTRUMENT_CLUSTER,occupantZoneId=0,inputTypes=DPAD_KEYS</item>
+        <item>displayPort=2,displayType=MAIN,occupantZoneId=1,inputTypes=TOUCH_SCREEN</item>
+        <item>displayPort=3,displayType=MAIN,occupantZoneId=2,inputTypes=TOUCH_SCREEN</item>
+        <item>displayPort=4,displayType=MAIN,occupantZoneId=3,inputTypes=TOUCH_SCREEN</item>
+
+        displayPort: Unique port id for the display.
+        displayType: Display type for the display. Use * part from
+                       CarOccupantZoneManager.DISPLAY_TYPE_* like MAIN, INSTRUMENT_CLUSTER and
+                       etc.
+        occupantZoneId: occupantZoneId specified from config_occupant_zones.
+
+        inputTypes: supported input types for the corresponding display.
+    -->
+    <string-array translatable="false" name="config_occupant_display_mapping">
+      <item>displayPort=0,displayType=MAIN,occupantZoneId=0,inputTypes=TOUCH_SCREEN|DPAD_KEYS|NAVIGATE_KEYS|ROTARY_NAVIGATION</item>
+      <item>displayPort=1,displayType=MAIN,occupantZoneId=1,inputTypes=TOUCH_SCREEN</item>
+      <item>displayPort=2,displayType=MAIN,occupantZoneId=2,inputTypes=TOUCH_SCREEN</item>
+      <item>displayPort=3,displayType=MAIN,occupantZoneId=3,inputTypes=TOUCH_SCREEN</item>
+    </string-array>
+
+    <!--
+    Specifies optional features that can be enabled by this image. Note that vhal can disable
+    them depending on product variation.
+    Feature name can be either service name defined in Car.*_SERVICE for Car*Manager or any
+    optional feature defined under @OptionalFeature annotation.
+    Note that '/' is used to have subfeature under main feature like "MAIN_FEATURE/SUB_FEATURE".
+
+    Some examples are:
+    <item>storage_monitoring</item>
+    <item>com.android.car.user.CarUserNoticeService</item>
+    <item>com.example.Feature/SubFeature</item>
+
+    The default list defined below will enable all optional features defined.
+    -->
+    <string-array translatable="false" name="config_allowed_optional_car_features">
+        <item>car_evs_service</item>
+        <item>car_navigation_service</item>
+        <item>car_occupant_connection_service</item>
+        <item>car_remote_device_service</item>
+        <item>com.android.car.user.CarUserNoticeService</item>
+        <item>diagnostic</item>
+        <item>storage_monitoring</item>
+        <item>vehicle_map_service</item>
+        <item>car_telemetry_service</item>
+    </string-array>
+
+    <!-- Enable profile user assignment per each CarOccupantZone for per display android user
+         assignments. This feature is still experimental. -->
+    <bool name="enableProfileUserAssignmentForMultiDisplay" translatable="false">true</bool>
+
+    <!-- The services that need to be started earlier in the boot sequence and in particular order.
+         Every item in this array contains a flatten component name of a service that needs to be
+         started and a list of parameters after hashtag symbol. Here's the format:
+
+         <item>com.bar.foo/.Service#bind={bind|start|startForeground},
+         user={all|system|foreground|visible|backgroundVisible},
+         trigger={asap|resume|userUnlocked|userPostUnlocked}</item>
+
+         bind: bind - start service with Context#bindService
+               start - start service with Context#startService
+               startForeground - start service with Context#startForegroundService
+               If service was bound it will be restarted unless it is constantly crashing.
+               The default value is 'start'
+         user: all - the service will be bound/started for system and all visible users
+               system - the service will be started/bound only for system user (u0)
+               foreground - the service will be bound/started only for foreground users
+               visible - the service will be bound/started only for visible users (as defined by
+                         `UserManager#isUserVisible()`).
+               backgroundVisible - the service will be bound/started only for background users that
+                                   are visible.
+               The default value is 'all'
+         trigger: indicates when the service needs to be started/bound
+               asap - the service might be bound when user is not fully loaded, be careful with
+                      this value, the service also needs to have directBootAware flag set to true
+               resume - start service when the device resumes from suspend (suspend-to-RAM, or
+                        suspend-to-disk).
+               userUnlocked - start service when user unlocked the device
+               userPostUnlocked - start service later after user unlocked. This is used when the
+                                  service is not urgent and can wait to start.
+               The default value is 'userUnlocked'
+         maxRetries: the maximum number of attempts to rebind/restart a disconnected service.
+               Retries start with 4 second initial delay, being doubled after each failed attempt.
+               The default value is 6.
+
+         If the service bound/started for foreground user it will be unbound/stopped when user
+         is no longer foreground.
+     -->
+    <string-array translatable="false" name="config_earlyStartupServices">
+        <item>com.google.android.companiondevicesupport/com.google.android.connecteddevice.service.ConnectedDeviceService#bind=bind,user=system,trigger=asap</item>
+        <item>com.google.android.companiondevicesupport/com.google.android.connecteddevice.service.ConnectedDeviceFgUserService#bind=bind,user=foreground,trigger=asap</item>
+        <!-- Starting Android Auto receiver service earlier for wireless projection. -->
+        <item>com.google.android.embedded.projection/com.google.android.apps.auto.aareceiver.service.PersistentService#bind=bind,user=foreground,trigger=userUnlocked</item>
+
+        <!-- eGMM Vehicle Map Service Provider -->
+        <item>com.google.android.apps.maps/com.google.android.apps.geo.autograph.vms.platform.car.CarVmsPublisherClientService#bind=bind,user=foreground,trigger=userUnlocked</item>
+
+        <!-- OEM Custom Input Reference Service -->
+        <item>com.android.car.custominput.sample/.SampleCustomInputService#bind=bind,user=foreground,trigger=userUnlocked</item>
+
+        <!-- Car Telemetry Collector Service -->
+        <item>com.android.car.cartelemetryapp/.CarMetricsCollectorService#bind=bind,user=system,trigger=asap</item>
+
+        <!-- GSR Failover service to facilitate the publishing of speed limit information when eGMM is unable to do so -->
+        <item>com.google.android.apps.geo.automotive.adas/.failover.FailoverControllerService#bind=bind,user=foreground,trigger=userUnlocked</item>
+
+        <!-- The service responsible for starting/stopping the Cast receiver. -->
+        <item>com.android.car.castreceiver/.AutomotiveCastReceiverService#bind=bind,user=foreground,trigger=userUnlocked</item>
+        <!-- Early start service for Multi-display Control Center app -->
+        <item>com.android.car.multidisplay.controlcenter/com.android.car.multidisplay.controlcenter.service.ControlCenterService#bind=bind,user=backgroundVisible,trigger=userPostUnlocked</item>
+    </string-array>
+</resources>

--- a/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/res/xml/car_ux_restrictions_map.xml
+++ b/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/res/xml/car_ux_restrictions_map.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2023, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<UxRestrictions xmlns:car="http://schemas.android.com/apk/res-auto">
+    <!-- Map the driving states to UX restrictions here -->
+    <!-- Note - The platform takes a fully restricted approach when there is no information or if
+    the information is malformed.  As a result,
+    1. Default values for requiresDistractionOptimization is true, and uxr is fully_restricted.
+    2. If uxr != baseline, then requiresDistractionOptimization is automatically promoted to true,
+    even if it is declared as false.  Because it doesn't make sense to have an non baseline UX
+    restriction without requiresDistractionOptimization set to true.
+    So if we don't want any restrictions, requiresDistractionOptimization should be explicitly
+    marked as false and uxr should be explicitly set to baseline. -->
+
+    <!--Setting baseline restrictions for all displays as this is a passenger only system-->
+    <RestrictionMapping physicalPort="0">
+        <DrivingState state="parked">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="idling">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="moving">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+    </RestrictionMapping>
+
+    <RestrictionMapping physicalPort="2">
+        <DrivingState state="parked">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="idling">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="moving">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+    </RestrictionMapping>
+
+    <RestrictionMapping physicalPort="3">
+        <DrivingState state="parked">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="idling">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="moving">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+    </RestrictionMapping>
+
+    <RestrictionMapping physicalPort="4">
+        <DrivingState state="parked">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="idling">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+        <DrivingState state="moving">
+            <Restrictions requiresDistractionOptimization="false" uxr="baseline"/>
+        </DrivingState>
+
+    </RestrictionMapping>
+
+    <!-- Configure restriction parameters here-->
+    <RestrictionParameters>
+        <!-- Parameters to express displayed String related restrictions -->
+        <!-- Max allowed length of general purpose strings when limit_string_length is imposed-->
+        <StringRestrictions maxLength="120"/>
+        <!-- Parameters to express content related restrictions -->
+        <!-- Max number of cumulative content items allowed to be displayed when
+        limit_content is imposed. -->
+        <!-- Maximum levels deep that the user can navigate to when limit_content is imposed. -->
+        <ContentRestrictions maxCumulativeItems="21" maxDepth="3"/>
+    </RestrictionParameters>
+
+</UxRestrictions>

--- a/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/res/xml/overlays.xml
+++ b/airdaydreamers/rpi5_car/rro_overlays/CarServiceOverlay_MultiDisplay/res/xml/overlays.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<overlay>
+    <item target="array/config_occupant_zones" value="@array/config_occupant_zones" />
+    <item target="array/config_occupant_display_mapping" value="@array/config_occupant_display_mapping" />
+    <item target="array/config_allowed_optional_car_features" value="@array/config_allowed_optional_car_features" />
+    <item target="bool/enableProfileUserAssignmentForMultiDisplay" value="@bool/enableProfileUserAssignmentForMultiDisplay" />
+    <item target="array/config_earlyStartupServices" value="@array/config_earlyStartupServices" />
+    <item target="xml/car_ux_restrictions_map" value="@xml/car_ux_restrictions_map" />
+</overlay>


### PR DESCRIPTION
Summary:
The android-rpi project has been updated to support Android TV on the Raspberry Pi 5. Additionally, new lunch targets have been added for the Raspberry Pi 5 platform.

Details:
- Added support for AAOS(Car) on the Raspberry Pi 5:
  - Ensured compatibility with existing features.
- Introduced new lunch targets:
  - Added configurations for AAOS to work seamlessly on Raspberry Pi hardware:
        - Car 
        - Car with multi-display support 
        - Car with portrait orientation support
  - Updated build scripts to include new AAOS targets.
- Modified build system to recognize and handle the new Raspberry Pi 5 targets.
- Tested the new configurations on Raspberry Pi 5 hardware to ensure stability and performance.

Issue:
Fixes: ----
Related: ----

Notes:
This is just the first round of changes. For some reason, performance is not good. Also, I have some questions about the Graphics Composer. It doesn't seem to work well and should be replaced. The default one from AOSP should be sufficient.